### PR TITLE
Adds Python 3.9 compatability by fixing asyncio api changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+markers = [
+  "asyncio"
+]

--- a/simpervisor/process.py
+++ b/simpervisor/process.py
@@ -80,7 +80,7 @@ class SupervisedProcess:
         # We could concurrently be in any other part of the code where
         # process is started or killed. So we check for that as soon
         # as we aquire the lock and behave accordingly.
-        with (await self._proc_lock):
+        async with self._proc_lock:
             if self.running:
                 # Don't wanna start it again, if we're already running
                 return
@@ -133,7 +133,7 @@ class SupervisedProcess:
         """
 
         # Aquire lock to modify process sate
-        with (await self._proc_lock):
+        async with self._proc_lock:
             # Don't yield control between sending signal & calling wait
             # This way, we don't end up in a call to _restart_process_if_needed
             # and possibly restarting. We also set _killed, just to be sure.

--- a/tests/child_scripts/signalprinter.py
+++ b/tests/child_scripts/signalprinter.py
@@ -23,4 +23,5 @@ finally:
     try:
         remaining_tasks = asyncio.all_tasks(loop=loop)
     except AttributeError:
+        # asyncio.all_tasks was added in 3. Provides reverse compatability.
         remaining_tasks = asyncio.Task.all_tasks(loop=loop)

--- a/tests/child_scripts/signalprinter.py
+++ b/tests/child_scripts/signalprinter.py
@@ -25,3 +25,5 @@ finally:
     except AttributeError:
         # asyncio.all_tasks was added in 3. Provides reverse compatability.
         remaining_tasks = asyncio.Task.all_tasks(loop=loop)
+    loop.run_until_complete(asyncio.gather(*remaining_tasks))
+    loop.close()

--- a/tests/child_scripts/signalprinter.py
+++ b/tests/child_scripts/signalprinter.py
@@ -5,7 +5,7 @@ import asyncio
 import signal
 from functools import partial
 import sys
-from simpervisor import atexitasync 
+from simpervisor import atexitasync
 
 def _handle_sigterm(number, received_signum):
     # Print the received signum so we know our handler was called
@@ -20,5 +20,7 @@ try:
     loop.run_forever()
 finally:
     # Cleanup properly so we get a clean exit
-    loop.run_until_complete(asyncio.gather(*asyncio.Task.all_tasks()))
-    loop.close()
+    try:
+        remaining_tasks = asyncio.all_tasks(loop=loop)
+    except AttributeError:
+        remaining_tasks = asyncio.Task.all_tasks(loop=loop)

--- a/tests/child_scripts/signalsupervisor.py
+++ b/tests/child_scripts/signalsupervisor.py
@@ -38,6 +38,7 @@ finally:
     try:
         remaining_tasks = asyncio.all_tasks(loop=loop)
     except AttributeError:
+        # asyncio.all_tasks was added in 3. Provides reverse compatability.
         remaining_tasks = asyncio.Task.all_tasks(loop=loop)
     loop.run_until_complete(asyncio.gather(*remaining_tasks))
     loop.close()

--- a/tests/child_scripts/signalsupervisor.py
+++ b/tests/child_scripts/signalsupervisor.py
@@ -35,6 +35,10 @@ try:
     loop.run_forever()
 finally:
     # Cleanup properly so we get a clean exit
-    loop.run_until_complete(asyncio.gather(*asyncio.Task.all_tasks()))
-    print('supervisor exiting cleanly')
+    try:
+        remaining_tasks = asyncio.all_tasks(loop=loop)
+    except AttributeError:
+        remaining_tasks = asyncio.Task.all_tasks(loop=loop)
+    loop.run_until_complete(asyncio.gather(*remaining_tasks))
     loop.close()
+    print("supervisor exiting cleanly")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py36,py37,py38,py39
+[testenv]
+deps =
+	-r dev-requirements.txt
+commands = pytest {posargs:--maxfail 3 --verbose}


### PR DESCRIPTION
[Python 3.7 deprecated `with await lock` syntax](https://docs.python.org/3.7/library/asyncio-sync.html#boundedsemaphore)

Python 3.7 deprecated "asyncio.Tasks.all_tasks" and added `asyncio.all_tasks`

This changes to the new API while maintaining 3.6 support.

Relates to https://github.com/ideonate/jhsingle-native-proxy/issues/8