### PR TITLE
Adds tox file for testing against multiple python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py36,py37,py38,py39
+[testenv]
+deps =
+	-r dev-requirements.txt
+commands = pytest {posargs:--maxfail 3 --verbose}


### PR DESCRIPTION
You can now test python3.6-3.9 with

```bash
$ tox
```